### PR TITLE
Extract bin

### DIFF
--- a/bin/fastatic
+++ b/bin/fastatic
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const fastatic = require('../index');
+const pkg = require('../package');
+
+const program = require('commander')
+	.version(pkg.version)
+	.description(`${pkg.name} (v${pkg.version}): ${pkg.description}`)
+	.usage('<src> [options]')
+	.option('-d, --dest [value]', 'Output destination')
+	.parse(process.argv);
+
+const src = program.args[0];
+
+
+if(src) {
+	fastatic({
+		src: program.args[0],
+		dest: program.dest
+	});
+} else {
+	console.log('Incorrect use. Try: `fastatic --help`');
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+const copy = require('./lib/copy');
 const promisify = require('bluebird').promisify;
-const copy = promisify(require('ncp').ncp);
 const remove = promisify(require('rimraf'));
 const stats = require('./lib/parser-stats');
 
@@ -32,19 +32,18 @@ function fastatic(options) {
 	const config = defineConfig(defaults, options);
 
 	// 1. copy to temp dir
-	//copy(config.src, config.temp)
-	// 2. optimise files (in parallel?)
-	//.then(parseAll(config))
-	parseAll(config)
-	// 3. revision files
-	// ...
+	copy(config.src, config.temp)
+	// 2. optimise files
+	.then(() => parseAll(config))
+	//// 3. revision files
+	//// ...
+	//// 4. display stats
 	.then(() => stats(config))
 	.then(output => console.log(output))
-	// 4. copy to final dest
-	// .then(() => copy(config.temp, config.dest))
-	// 5. remove temp dir
+	//// 5. copy to final dest
+	.then(() => copy(config.temp, config.dest))
 	.catch(err => console.log('error', err)) // if anything goes wrong, we skip all steps, catch errors and remove temp
-	//.then(() => remove(config.temp))
+	.then(() => remove(config.temp))
 	.then(() => console.log('Done. Optimised static files in', config.dest));
 }
 

--- a/index.js
+++ b/index.js
@@ -72,32 +72,4 @@ function parseAll(config) {
 }
 
 
-fastatic({
-	src: 'examples/react-gh-pages/',
-	dest: 'examples/react/'
-});
-
-
-
-if (require.main === module) {
-	// if used from cli, parse arguments and call fastatic with it
-	// @todo: move to bin.js / cli.js?
-	const pkg = require('./package');
-	const program = require('commander')
-		.version(pkg.version)
-		.description(`${pkg.name} (v${pkg.version}): ${pkg.description}`)
-		.usage('<src> [options]')
-		.option('-d, --dest [value]', 'Output destination')
-		.parse(process.argv);
-
-	if(!program.args[0]) {
-		return;
-	}
-
-	fastatic({
-		src: program.args[0],
-		dest: program.dest
-	});
-}
-
 module.exports = fastatic;

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,0 +1,14 @@
+const fse = require('fs-extra');
+
+function copy (src, dest, options) {
+	return new Promise((resolve, reject) => {
+		try {
+			fse.copySync(src, dest, options);
+			resolve();
+		} catch(err) {
+			reject(err);
+		}
+	});
+}
+
+module.exports = copy;

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "fastatic",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Speed up your static site",
-  "bin": "index.js",
+  "bin": {
+    "fastatic": "./bin/fastatic"
+  },
   "private": true,
   "main": "index.js",
   "scripts": {
-    "build": "node index.js",
-    "fastatic:help": "node ./ --help",
-    "fastatic:version": "node ./ --version",
-    "fastatic:react": "node ./ examples/react-gh-pages/ --dest examples/react/",
+    "fastatic:help": "./bin/fastatic --help",
+    "fastatic:version": "./bin/fastatic --version",
+    "fastatic:react": "./bin/fastatic examples/react-gh-pages/ --dest examples/react/",
     "ngrok": "ngrok http 3278",
     "start": "http-server 'examples/' -c-1 -o -p 3278",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "build": "npm run copy && node index.js",
-    "copy": "ncp examples/react-gh-pages/ examples/react/",
+    "build": "node index.js",
     "fastatic:help": "node ./ --help",
     "fastatic:version": "node ./ --version",
     "fastatic:react": "node ./ examples/react-gh-pages/ --dest examples/react/",
@@ -41,6 +40,7 @@
     "cli-table": "0.3.1",
     "commander": "2.9.0",
     "filesize": "3.3.0",
+    "fs-extra": "0.30.0",
     "gulp": "3.9.1",
     "gulp-clean-css": "2.0.12",
     "gulp-htmlmin": "2.0.0",
@@ -49,7 +49,6 @@
     "imagemin-mozjpeg": "6.0.0",
     "imagemin-pngquant": "5.0.0",
     "imagemin-svgo": "5.1.0",
-    "ncp": "2.0.0",
     "pump": "1.0.1",
     "rimraf": "2.5.4"
   }


### PR DESCRIPTION
Extract program from index and register in package as `bin:fastatic`.

Is based on #26 so that one should be approved and merged first.

Removed `build` script as that was just a temporary and fake test script. For testing use `npm run fastatic:react` etc instead.
