### PR TITLE
feat(parse-xml): use pretty-data to minify all .xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ parser | pattern | function
 --- | --- | ---
 `css` | `**/*.css` | Minify stylesheets
 `js` | `**/*.js` | Minify javascript files
-`json` | `**/*.json` | Minify json files by removing all whitespace and comments. 
+`json` | `**/*.json` | Minify json files by removing all whitespace
 `html` | `**/*.html` | Minify HTML by removing whitespace and minifying inline css/javascript
 `images` | `**/*.{gif,jpg,jpeg,png,svg}` | Optimize images and SVG files
+`xml` | `**/*.xml` | Minify XML files by removing all whitespace and comments
 
 
 ## Available tasks

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const defaults = {
 		json: {
 			pattern: '**/*.json',
 			parser: require('./lib/parse-json')
+		},
+		xml: {
+			pattern: '**/*.xml',
+			parser: require('./lib/parse-xml')
 		}
 	}
 };

--- a/lib/parse-json.js
+++ b/lib/parse-json.js
@@ -1,6 +1,8 @@
 const parser = require('./parser');
-const jsonminify = require('gulp-jsonminify');
+const prettyData = require('gulp-pretty-data');
 
 module.exports = parser([
-	jsonminify()
+	prettyData({
+		type: 'minify'
+	})
 ]);

--- a/lib/parse-xml.js
+++ b/lib/parse-xml.js
@@ -1,0 +1,9 @@
+const parser = require('./parser');
+const prettyData = require('gulp-pretty-data');
+
+module.exports = parser([
+	prettyData({
+		type: 'minify',
+		preserveComments: true
+	})
+]);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "gulp-clean-css": "2.0.12",
     "gulp-htmlmin": "2.0.0",
     "gulp-imagemin": "3.0.2",
-    "gulp-jsonminify": "1.0.0",
     "gulp-pretty-data": "0.1.1",
     "gulp-uglify": "1.5.4",
     "imagemin-mozjpeg": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-htmlmin": "2.0.0",
     "gulp-imagemin": "3.0.2",
     "gulp-jsonminify": "1.0.0",
+    "gulp-pretty-data": "0.1.1",
     "gulp-uglify": "1.5.4",
     "imagemin-mozjpeg": "6.0.0",
     "imagemin-pngquant": "5.0.0",


### PR DESCRIPTION
closes #16

Tested on `examples/react-gh-pages` and checked results are the same with [W3C Feed Validation Service](https://validator.w3.org/feed/#validate_by_input). Savings are not really significant, but that's mainly because there's very little XML and the contents of the XML were mainly escaped HTML:

<img width="379" alt="XML saving stats" src="https://cloud.githubusercontent.com/assets/1516059/17398211/eaaf3f30-5a3b-11e6-9012-59d2378be681.png">
