### PR TITLE
Default dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,71 @@
 # Fastatic
-> Speed up your static site with one command
+
+**Speed up your static site with one command: `fastatic`**
+
 
 ## Usage
 
-### CLI
+Fastatic works out-of-the-box with zero configuration.
+
+You can use Fastatic both as a [CLI tool](#cli) and [programmatically in JS](#js).
+
+
+### Install
+
+Fastatic is written in [Node.js](http://nodejs.org/) and can be installed via [npm](https://npmjs.org/):
 
 ```bash
-$ fastatic my-static-site/
+$ npm install fastatic
 ```
 
+### CLI
+
+Optimise all static files in **current directory**:
+
 ```bash
-$ fastatic my-static-site-source/ --dest my-static-site/
+$ fastatic
+```
+
+Optimise all static files in a **specific directory**:
+
+```bash
+$ fastatic my-static-site-source/
+```
+
+Optimise all static files from a specific directory and **output to a different directory** using `--dest`:
+
+```bash
+$ fastatic my-static-site-source/ --dest my-static-site-dest/
 ```
 
 ### JS
 
+To use Fastatic programmatically import the `fastatic` module:
+
 ```javascript
 const fastatic = require('fastatic');
+```
+
+Optimise all static files in **current directory**:
+
+```javascript
 fastatic();
 ```
 
-#### Configure patterns
+Optimise all static files in a **specific directory**:
+
+```javascript
+fastatic({ src: 'my-static-site-source/' });
+```
+
+Optimise all static files from a specific directory and **output to a different directory**:
+
+```javascript
+fastatic({ src: 'my-static-site-source/', dest: 'my-static-site-dest/' });
+```
+
+
+#### Configure parser pattern
 
 ```javascript
 // configure patterns:
@@ -62,5 +107,5 @@ task | function
 
 ## Known limitations
 
-* *Fastastic* doesn't concatenate files (css / js ) because there is no reliable way to determine the combinations in which these files are served, nor does it know about the protocol over which it's served (HTTP/1 or HTTP/2).
-* *Fastastic* doesn't resize images (png / jpg / gif) because there is no reliable way to determine which sizes the images are displayed in.
+* Fastastic doesn't concatenate files (css / js) because there is no reliable way to determine the combinations in which these files are served, nor does it know about the protocol over which it's served (HTTP/1 or HTTP/2).
+* Fastastic doesn't resize images (png / jpg / gif) because there is no reliable way to determine which sizes the images are displayed in.

--- a/bin/fastatic
+++ b/bin/fastatic
@@ -15,7 +15,7 @@ const src = program.args[0];
 
 if(src) {
 	fastatic({
-		src: program.args[0],
+		src: src,
 		dest: program.dest
 	});
 } else {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const stats = require('./lib/parser-stats');
 
 const defaults = {
 	src: './',
-	dest: './',
+	dest: undefined,
 	temp: './.fastatic-temp/',
 	parsers: {
 		css: {
@@ -58,6 +58,8 @@ function fastatic(options) {
 
 function defineConfig(defaults, options) {
 	const config = Object.assign({}, defaults, options);
+	config.dest = config.dest || config.src;
+
 	Object.keys(config.parsers).forEach(name => {
 		if (!config.parsers[name]) {
 			delete config.parsers[name];

--- a/lib/parser-stats.js
+++ b/lib/parser-stats.js
@@ -3,6 +3,7 @@ const filesize = require('filesize');
 const fs = require('fs');
 const promisify = require('bluebird').promisify;
 const glob = promisify(require('glob').glob);
+const path = require('path');
 const percent = require('calc-percent');
 const Table = require('cli-table');
 
@@ -23,7 +24,7 @@ function stats(config) {
 
 
 function getSumOfFileSize(location, pattern) {
-	return glob(location + pattern)
+	return glob(path.join(location, pattern))
 		.then(function(files) {
 			return Promise.all(files.map(file => new Promise((resolve, reject) => {
 				fs.stat(file, (err, stat) => err ? reject(err) : resolve(stat.size))

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp');
+const path = require('path');
 const pump = require('pump');
 
 /**
@@ -10,7 +11,7 @@ function parser (processors) {
 		console.log('Parsing', config.src + config.pattern);
 		return new Promise((resolve, reject) => {
 			pump([
-				gulp.src(config.src + config.pattern),
+				gulp.src(path.join(config.src, config.pattern)),
 				...processors,
 				gulp.dest(config.dest)
 			], (err) => {


### PR DESCRIPTION
Default `config.dest` to `config.src` inside core module, so it works for both cli and programmatic use.

Fix path normalisation so you can type both `{ src: 'dir/' }` and `{ src: 'dir' }` (mind the **`/`**).

Improve docs to explain better how to use Fastatic via cli and programmatically. With the different ways you can run it (no config, src only, src + dest).

Closes #32 (and replaces PR #37). 
