### PR TITLE
Execute parsers based on dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const copy = require('./lib/copy');
+const parseAll = require('./lib/parse-all');
 const promisify = require('bluebird').promisify;
 const remove = promisify(require('rimraf'));
 const stats = require('./lib/parser-stats');
@@ -61,7 +62,6 @@ function fastatic(options) {
 	.then(() => console.log('Done. Optimised static files in', config.dest));
 }
 
-
 function defineConfig(defaults, options) {
 	const config = Object.assign({}, defaults, options);
 	config.dest = config.dest || config.src;
@@ -73,19 +73,5 @@ function defineConfig(defaults, options) {
 	});
 	return config;
 }
-
-
-function parseAll(config) {
-	return Promise.all(
-		Object.keys(config.parsers).map(function(name) {
-			return config.parsers[name].parser({
-				src: config.src,
-				dest: config.temp,
-				pattern: config.parsers[name].pattern
-			});
-		})
-	);
-}
-
 
 module.exports = fastatic;

--- a/index.js
+++ b/index.js
@@ -1,42 +1,11 @@
 const copy = require('./lib/copy');
+const defaults = require('./lib/defaults');
+const merge = require('lodash/merge');
 const parseAll = require('./lib/parse-all');
 const promisify = require('bluebird').promisify;
 const remove = promisify(require('rimraf'));
 const stats = require('./lib/parser-stats');
 const Spinner = require('cli-spinner').Spinner;
-
-const defaults = {
-	src: './',
-	dest: undefined,
-	temp: './.fastatic-temp/',
-	parsers: {
-		cssmin: {
-			pattern: '**/*.css',
-			parser: require('./lib/parse-cssmin')
-		},
-		htmlmin: {
-			pattern: '**/*.html',
-			parser: require('./lib/parse-htmlmin')
-		},
-		imagesmin: {
-			pattern: '**/*.{gif,jpg,jpeg,png,svg}',
-			parser: require('./lib/parse-imagesmin')
-		},
-		jsmin: {
-			pattern: '**/*.js',
-			parser: require('./lib/parse-jsmin')
-		},
-		jsonmin: {
-			pattern: '**/*.json',
-			parser: require('./lib/parse-jsonmin')
-		},
-		xmlmin: {
-			pattern: '**/*.xml',
-			parser: require('./lib/parse-xmlmin')
-		}
-	}
-};
-
 
 function fastatic(options) {
 	const config = defineConfig(defaults, options);
@@ -63,7 +32,7 @@ function fastatic(options) {
 }
 
 function defineConfig(defaults, options) {
-	const config = Object.assign({}, defaults, options);
+	const config = merge({}, defaults, options);
 	config.dest = config.dest || config.src;
 
 	Object.keys(config.parsers).forEach(name => {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,7 +8,6 @@ const defaults = {
 			parser: require('./parse-cssmin')
 		},
 		htmlmin: {
-			dependsOn: ['imagesmin'],
 			pattern: '**/*.html',
 			parser: require('./parse-htmlmin')
 		},

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,34 @@
+const defaults = {
+	src: './',
+	dest: undefined,
+	temp: './.fastatic-temp/',
+	parsers: {
+		cssmin: {
+			pattern: '**/*.css',
+			parser: require('./parse-cssmin')
+		},
+		htmlmin: {
+			dependsOn: ['imagesmin'],
+			pattern: '**/*.html',
+			parser: require('./parse-htmlmin')
+		},
+		imagesmin: {
+			pattern: '**/*.{gif,jpg,jpeg,png,svg}',
+			parser: require('./parse-imagesmin')
+		},
+		jsmin: {
+			pattern: '**/*.js',
+			parser: require('./parse-jsmin')
+		},
+		jsonmin: {
+			pattern: '**/*.json',
+			parser: require('./parse-jsonmin')
+		},
+		xmlmin: {
+			pattern: '**/*.xml',
+			parser: require('./parse-xmlmin')
+		}
+	}
+};
+
+module.exports = defaults;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -28,6 +28,18 @@ const defaults = {
 			pattern: '**/*.xml',
 			parser: require('./parse-xmlmin')
 		}
+	},
+	fileTypeDisplayName: {
+		css: 'CSS',
+		gif: 'Images',
+		html: 'HTML',
+		jpeg: 'Images',
+		jpg: 'Images',
+		js: 'JavaScript',
+		json: 'JSON',
+		png: 'Images',
+		svg: 'Images',
+		xml: 'XML'
 	}
 };
 

--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class Deferred {
+	constructor() {
+		this.promise = new Promise((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+}
+
+module.exports = Deferred;

--- a/lib/parse-all.js
+++ b/lib/parse-all.js
@@ -1,0 +1,26 @@
+const Deferred = require('./deferred');
+
+function parseAll(config) {
+
+	const parsing = Object.keys(config.parsers).reduce((map, name) => {
+		map[name] = new Deferred();
+		return map;
+	}, {});
+
+	return Promise.all(
+		Object.keys(config.parsers).map((name) => {
+			const parserObj = config.parsers[name];
+			const deps = parserObj.dependsOn || [];
+			return Promise.all(deps.map(dep => parsing[dep].promise))
+				.then(() => config.parsers[name].parser({
+					src: config.src,
+					dest: config.temp,
+					pattern: config.parsers[name].pattern
+				}))
+				.then(res => parsing[name].resolve(res))
+				.catch(err => parsing[name].reject(err));
+		})
+	);
+}
+
+module.exports = parseAll;

--- a/lib/parser-stats.js
+++ b/lib/parser-stats.js
@@ -3,6 +3,8 @@ const filesize = require('filesize');
 const fs = require('fs');
 const promisify = require('bluebird').promisify;
 const glob = promisify(require('glob').glob);
+const includes = require('lodash/includes');
+const merge = require('lodash/merge');
 const path = require('path');
 const percent = require('calc-percent');
 const Table = require('cli-table');
@@ -19,6 +21,7 @@ function stats(config) {
 				])
 			})
 		)
+		.then(sizes => addDisplayName(sizes, config))
 		.then(sizes => createSizesTable(sizes).toString());
 }
 
@@ -36,6 +39,22 @@ function getSumOfFileSize(location, pattern) {
 		}))
 }
 
+function addDisplayName(sizes, config) {
+	const fileTypesMap = config.fileTypeDisplayName;
+	const fileTypes = Object.keys(fileTypesMap);
+	const augmentedSizes = sizes.map((size) => {
+		return size.map((s) => {
+			const fileTypeRe = /(?:\.)(?:{*)([\w,]+)(?:}*)$/ig;
+			const fileTypeMatch = fileTypeRe.exec(s.pattern);
+			const matchedFileTypes = (fileTypeMatch) ? fileTypeMatch[1].split(',') : [ '' ];
+			const fileTypeInMap = matchedFileTypes.some((type) => includes(fileTypes, type));
+			const displayName = (fileTypeInMap && fileTypesMap[matchedFileTypes[0]]) ? { displayName: fileTypesMap[matchedFileTypes[0]] } : {};
+
+			return merge(s, displayName);
+		})
+	});
+	return sizes;
+}
 
 function createSizesTable(sizes) {
 	const table = new Table({
@@ -57,7 +76,7 @@ function createSizesTable(sizes) {
 			const isTotal = src.pattern !== '**/*';
 
 			if(isTotal) {
-				row.push(src.pattern);
+				row.push(src.displayName || src.pattern);
 			} else {
 				row.push(colors.bold.green('Total'));
 			}

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "bluebird": "3.4.1",
     "calc-percent": "1.0.1",
-    "cli-table": "0.3.1",
     "cli-spinner": "0.2.5",
+    "cli-table": "0.3.1",
     "colors": "1.1.2",
     "commander": "2.9.0",
     "filesize": "3.3.0",
@@ -66,6 +66,7 @@
     "imagemin-mozjpeg": "6.0.0",
     "imagemin-pngquant": "5.0.0",
     "imagemin-svgo": "5.1.0",
+    "lodash": "4.15.0",
     "pump": "1.0.1",
     "rimraf": "2.5.4"
   }


### PR DESCRIPTION
The parsers are executed when their dependencies are met. By adding a `dependsOn` array with the dependencies of a parser, the parser is executed once all parsers in the array are finished.

```
cssmin: {
    pattern: '**/*.css',
    parser: require('./parse-cssmin')
},
csscritical: {
    dependsOn: ['cssmin'],
    pattern: '**/*.css',
    parser: require('./parse-cssmin')
},
```

Also part of this PR (should have been its own PR), rendering human readable file types in the table instead of file patterns.
