### PR TITLE
Examples output in different folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .fastatic-temp/
 npm-debug.log
+examples/_build/

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "fastatic:help": "./bin/fastatic --help",
     "fastatic:version": "./bin/fastatic --version",
-    "fastatic:microsoft": "./bin/fastatic examples/microsoft.github.io-master/ --dest examples/microsoft/",
-    "fastatic:react": "./bin/fastatic examples/react-gh-pages/ --dest examples/react/",
-    "fastatic:bootstrap": "./bin/fastatic examples/bootstrap-gh-pages/ --dest examples/bootstrap/",
+    "fastatic:microsoft": "./bin/fastatic examples/microsoft.github.io-master/ --dest examples/_build/microsoft/",
+    "fastatic:react": "./bin/fastatic examples/react-gh-pages/ --dest examples/_build/react/",
+    "fastatic:bootstrap": "./bin/fastatic examples/bootstrap-gh-pages/ --dest examples/_build/bootstrap/",
     "ngrok": "ngrok http 3278",
     "start": "http-server 'examples/' -c-1 -o -p 3278",
     "test": "eslint index.js /lib /bin",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "scripts": {
     "fastatic:help": "./bin/fastatic --help",
     "fastatic:version": "./bin/fastatic --version",
-    "fastatic:microsoft": "./bin/fastatic examples/microsoft.github.io-master/ --dest examples/_build/microsoft/",
-    "fastatic:react": "./bin/fastatic examples/react-gh-pages/ --dest examples/_build/react/",
-    "fastatic:bootstrap": "./bin/fastatic examples/bootstrap-gh-pages/ --dest examples/_build/bootstrap/",
+    "examples": "npm-run-all --serial examples:*",
+    "examples:microsoft": "./bin/fastatic examples/microsoft.github.io-master/ --dest examples/_build/microsoft/",
+    "examples:react": "./bin/fastatic examples/react-gh-pages/ --dest examples/_build/react/",
+    "examples:bootstrap": "./bin/fastatic examples/bootstrap-gh-pages/ --dest examples/_build/bootstrap/",
     "ngrok": "ngrok http 3278",
     "start": "http-server 'examples/' -c-1 -o -p 3278",
     "test": "eslint index.js /lib /bin",
@@ -46,7 +47,8 @@
     "cz-conventional-changelog": "1.2.0",
     "eslint": "3.3.1",
     "http-server": "0.9.0",
-    "ngrok": "2.2.2"
+    "ngrok": "2.2.2",
+    "npm-run-all": "2.3.0"
   },
   "dependencies": {
     "bluebird": "3.4.1",


### PR DESCRIPTION
Following the #48 issue, example builds are ignored. Examples can be run with `$ npm run examples`
