### PR TITLE
refactor(parser-stats): convert file patterns into human readable types

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,18 @@ const defaults = {
 			pattern: '**/*.xml',
 			parser: require('./lib/parse-xmlmin')
 		}
+	},
+	fileTypeDisplayName: {
+		css: 'CSS',
+		gif: 'Images',
+		html: 'HTML',
+		jpeg: 'Images',
+		jpg: 'Images',
+		js: 'JavaScript',
+		json: 'JSON',
+		png: 'Images',
+		svg: 'Images',
+		xml: 'XML'
 	}
 };
 

--- a/lib/parser-stats.js
+++ b/lib/parser-stats.js
@@ -3,6 +3,8 @@ const filesize = require('filesize');
 const fs = require('fs');
 const promisify = require('bluebird').promisify;
 const glob = promisify(require('glob').glob);
+const includes = require('lodash/includes');
+const merge = require('lodash/merge');
 const path = require('path');
 const percent = require('calc-percent');
 const Table = require('cli-table');
@@ -19,6 +21,7 @@ function stats(config) {
 				])
 			})
 		)
+		.then(sizes => addDisplayName(sizes, config))
 		.then(sizes => createSizesTable(sizes).toString());
 }
 
@@ -36,6 +39,22 @@ function getSumOfFileSize(location, pattern) {
 		}))
 }
 
+function addDisplayName(sizes, config) {
+	const fileTypesMap = config.fileTypeDisplayName;
+	const fileTypes = Object.keys(fileTypesMap);
+	const augmentedSizes = sizes.map((size) => {
+		return size.map((s) => {
+			const fileTypeRe = /(?:\.)(?:{*)([\w,]+)(?:}*)$/ig;
+			const fileTypeMatch = fileTypeRe.exec(s.pattern);
+			const matchedFileTypes = (fileTypeMatch) ? fileTypeMatch[1].split(',') : [ '' ];
+			const fileTypeInMap = matchedFileTypes.some((type) => includes(fileTypes, type));
+			const displayName = (fileTypeInMap && fileTypesMap[matchedFileTypes[0]]) ? { displayName: fileTypesMap[matchedFileTypes[0]] } : {};
+
+			return merge(s, displayName);
+		})
+	});
+	return sizes;
+}
 
 function createSizesTable(sizes) {
 	const table = new Table({
@@ -57,7 +76,7 @@ function createSizesTable(sizes) {
 			const isTotal = src.pattern !== '**/*';
 
 			if(isTotal) {
-				row.push(src.pattern);
+				row.push(src.displayName || src.pattern);
 			} else {
 				row.push(colors.bold.green('Total'));
 			}

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "bluebird": "3.4.1",
     "calc-percent": "1.0.1",
-    "cli-table": "0.3.1",
     "cli-spinner": "0.2.5",
+    "cli-table": "0.3.1",
     "colors": "1.1.2",
     "commander": "2.9.0",
     "filesize": "3.3.0",
@@ -66,6 +66,7 @@
     "imagemin-mozjpeg": "6.0.0",
     "imagemin-pngquant": "5.0.0",
     "imagemin-svgo": "5.1.0",
+    "lodash": "4.15.0",
     "pump": "1.0.1",
     "rimraf": "2.5.4"
   }


### PR DESCRIPTION
File patterns are converted into human readable filetypes in the table, so `**/*.css` becomes `CSS`
