### PR TITLE
fix(parser): explicitly set `base` for patterns not starting with wildcard

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,24 +2,14 @@ const gulp = require('gulp');
 const path = require('path');
 const pump = require('pump');
 
-/**
- * @todo logging / progress indication?
- * @todo generic success / error handling?
- */
 function parser (processors) {
 	return function (config) {
 		return new Promise((resolve, reject) => {
 			pump([
-				gulp.src(path.join(config.src, config.pattern)),
+				gulp.src(path.join(config.src, config.pattern), { base: config.src }),
 				...processors,
 				gulp.dest(config.dest)
-			], (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					resolve();
-				}
-			})
+			], (err) => err ? reject(err) : resolve())
 		});
 	}
 }


### PR DESCRIPTION
before output would go to wrong directly if pattern doesn't start with a wildcard
`**/*.js` was fine
`assets/*.js` would fail as it would use src dir + `assets/` as base instead of src dir
