### PR TITLE
chore(build): format readme as HTML page using

### DIFF
--- a/lib/rebase-relative-urls.js
+++ b/lib/rebase-relative-urls.js
@@ -1,0 +1,31 @@
+const cheerio = require('cheerio');
+const isRelativeUrl = require('is-relative-url');
+
+/**
+ * The `[href]` of anchors in the given `html` with a relative url are prefixed with the given `baseUrl`.
+ *
+ * So with a `baseUrl` of `https://example.com/` an href of `path/to/page/` becomes `https://example.com/path/to/page/`,
+ * but in-page links (e.g. `#options`) and absolute urls (e.g. `https://google.com`) remain unchanged.
+ *
+ * @param {String} html         markup string containing anchors with hrefs
+ * @param {String} baseUrl      url to prepend to all relative links
+ * @returns {String}            markup string with rebased hrefs
+ */
+function rebaseRelativeUrls(html, baseUrl) {
+	baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+	const $ = cheerio.load(html);
+	$('a').each((index, link) => {
+		const $link = $(link);
+		const href = $link.attr('href');
+		if (isRelativeExternalUrl(href)) {
+			$link.attr('href', baseUrl + href);
+		}
+	});
+	return $.html();
+}
+
+function isRelativeExternalUrl(url) {
+	return isRelativeUrl(url) && !url.startsWith('#');
+}
+
+module.exports = rebaseRelativeUrls;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "examples:bootstrap": "./bin/fastatic examples/bootstrap-gh-pages/ --dest build/examples/bootstrap/",
     "examples:nodejs": "./bin/fastatic examples/nodejs/ --dest build/examples/nodejs/",
     "postexamples:react": "node ./scripts/replace-react-paths.js",
-    "build": "run-s examples build:readme build:readme build:examples-index",
-    "build:readme": "marked README.md -o 'build/index.html'",
+    "build": "run-s examples build:index build:examples-index",
+    "build:index": "node scripts/build-index.js",
     "build:examples-index": "marked examples/README.md -o 'build/examples/index.html'",
     "build:travis": "run-s build",
     "postbuild:travis": "node ./scripts/replace-react-paths-travis.js",
@@ -52,12 +52,15 @@
     }
   },
   "devDependencies": {
+    "cheerio": "0.22.0",
     "commitizen": "2.8.6",
     "conventional-changelog-cli": "1.2.0",
     "cz-conventional-changelog": "1.2.0",
     "eslint": "3.8.1",
     "http-server": "0.9.0",
-    "ngrok": "2.2.3"
+    "is-relative-url": "2.0.0",
+    "ngrok": "2.2.3",
+    "voorhoede-ocelot-formatter": "0.3.2"
   },
   "dependencies": {
     "bluebird": "3.4.6",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "http-server": "0.9.0",
     "is-relative-url": "2.0.0",
     "ngrok": "2.2.3",
-    "voorhoede-ocelot-formatter": "0.3.2"
+    "voorhoede-ocelot-formatter": "0.4.2"
   },
   "dependencies": {
     "bluebird": "3.4.6",

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -11,7 +11,7 @@ fs.readFile('README.md', 'utf8', (err, readme) => {
 		console.error('Error reading README.md', err);
 		return;
 	}
-	formatter(readme)
+	formatter(readme, { github: 'voorhoede/fastatic' })
 		.then(html => rebaseRelativeUrls(html, masterBranchUrl))
 		.then(html => fs.writeFile(outputFilename, html));
 });

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -1,0 +1,17 @@
+const formatter = require('voorhoede-ocelot-formatter');
+const fs = require('fs');
+const pkg = require('../package.json');
+const rebaseRelativeUrls = require('../lib/rebase-relative-urls');
+
+const masterBranchUrl = pkg.repository.url + '/blob/master/';
+const outputFilename = 'build/index.html';
+
+fs.readFile('README.md', 'utf8', (err, readme) => {
+	if (err) {
+		console.error('Error reading README.md', err);
+		return;
+	}
+	formatter(readme)
+		.then(html => rebaseRelativeUrls(html, masterBranchUrl))
+		.then(html => fs.writeFile(outputFilename, html));
+});


### PR DESCRIPTION
* Format README.md as HTML page using `voorhoede-ocelot-formatter`
* Rebase relative links inside the HTML page
* Write HTML page to `build/index.html` so it becomes the new project index page